### PR TITLE
Add merge Link header to patch request resource

### DIFF
--- a/periodo.py
+++ b/periodo.py
@@ -581,8 +581,16 @@ class PatchRequest(Resource):
         if not row:
             abort(404)
         data = process_patch_row(row)
-        data['mergeable'] = is_mergeable(data['text'])
-        return marshal(data, patch_fields)
+        data['mergeable'] = is_mergeable(data['original_patch'])
+        headers = {}
+
+        try:
+            if accept_patch_permission.can():
+                headers['Link'] = '<{}>;rel="merge"'.format(url_for('patchmerge', id=id))
+        except AuthenticationFailed:
+            pass
+
+        return marshal(data, patch_fields), 200, headers
 
 @api.resource('/patches/<int:id>/patch.jsonpatch')
 class Patch(Resource):

--- a/void-stub.ttl
+++ b/void-stub.ttl
@@ -24,7 +24,7 @@
       orcid:0000-0003-2557-5145 ,
       orcid:0000-0001-5620-4764 ,
       orcid:0000-0002-3617-9378 ,
-      orcid:0000-0002-4871-039X ;
+      _:sarahab ;
    wv:waiver <http://creativecommons.org/publicdomain/zero/1.0/> ;
    wv:norms <http://www.opendatacommons.org/norms/odc-by-sa/> ;
    wv:declaration "To the extent allowed by law, the contributors have dedicated the PeriodO dataset to the public domain by waiving all of their rights to the work worldwide under copyright law, including all related and neighboring rights. You can copy, modify, and distribute this dataset, even for commercial purposes, all without asking permission. However, if you desire our respect and cooperation, then you will clearly attribute your use of our work and share your own work in kind (even though you are not required to in any way)."@en ;
@@ -59,6 +59,6 @@ orcid:0000-0002-3617-9378 a foaf:Person ;
    rdfs:label "Patrick Golden" ;
    foaf:mbox <mailto:ptgolden@berkeley.edu> .
 
-orcid:0000-0002-4871-039X a foaf:Person ;
-   rdfs:label "Sarah Buchanan" ;
+_:sarahab a foaf:Person ;
+   rdfs:label "Sarah A. Buchanan" ;
    foaf:mbox <mailto:sarahab@utexas.edu> .


### PR DESCRIPTION
If a user is authorized, this adds a Link header to a patch request resource that includes a link to the merge resource.