### PR TITLE
Override content negotation for content-type-specific URLs.

### DIFF
--- a/periodo.py
+++ b/periodo.py
@@ -59,6 +59,11 @@ class PeriodOApi(Api):
         else:
             return response
     def make_response(self, data, *args, **kwargs):
+        # Override content negotation for content-type-specific URLs.
+        if request.path.endswith('.json'):
+            res = self.representations['application/json'](data, *args, **kwargs)
+            res.content_type = 'application/json'
+            return res
         if request.path.endswith('.jsonld'):
             res = self.representations['application/json'](data, *args, **kwargs)
             res.content_type = 'application/ld+json'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-aniso8601==0.92
+aniso8601==1.0.0
 blinker==1.3
 Flask-Principal==0.4.0
-Flask-RESTful==0.3.1
+Flask-RESTful==0.3.3
 Flask==0.10.1
 isodate==0.5.1
 itsdangerous==0.24
@@ -11,9 +11,9 @@ jsonpointer==1.7
 MarkupSafe==0.23
 pip-tools==0.3.5
 pyparsing==2.0.3
-pytz==2014.10
+pytz==2015.4
 rdflib-jsonld==0.2
 rdflib==4.1.2
 requests==2.5.1
 six==1.9.0
-Werkzeug==0.9.6
+Werkzeug==0.10.4

--- a/test/tests.py
+++ b/test/tests.py
@@ -440,6 +440,12 @@ WHERE {
         res4 = self.app.get('/d/', headers={ 'Accept': 'application/ld+json' })
         self.assertEqual(res4.status_code, http.client.OK)
         self.assertEqual(res4.headers['Content-Type'], 'application/ld+json')
+        res5 = self.app.get('/d.json', headers={ 'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8' })
+        self.assertEqual(res5.status_code, http.client.OK)
+        self.assertEqual(res5.headers['Content-Type'], 'application/json')
+        res6 = self.app.get('/d.jsonld', headers={ 'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8' })
+        self.assertEqual(res6.status_code, http.client.OK)
+        self.assertEqual(res6.headers['Content-Type'], 'application/ld+json')
         g = Graph().parse(data=res4.get_data(as_text=True), format='json-ld')
         self.assertIn((PERIODO['p0d/#periodCollections'],
                        FOAF.isPrimaryTopicOf, PERIODO['p0d/']), g)


### PR DESCRIPTION
When requesting a URL like `http://n2t.net/ark:/99152/p05krdxpb2m.json` from a browser, a `406 Not Acceptable` response was being sent because Flask-RESTful's support for content negotiation isn't too great. So, we override it in this case and always send JSON (or JSON-LD) no matter what the `Accept` header says.