### PR TITLE
Better handling of removed entities

### DIFF
--- a/periodo/database.py
+++ b/periodo/database.py
@@ -1,3 +1,4 @@
+import itertools
 import json
 import sqlite3
 from periodo import app
@@ -42,6 +43,12 @@ def find_version_of_last_update(entity_id, version):
         if entity_id in json.loads(row['updated_entities']):
             return row['resulted_in']
     return None
+
+
+def get_removed_entity_keys():
+    return set(itertools.chain(
+        *[json.loads(row['removed_entities']) for row in query_db('''
+SELECT removed_entities FROM patch_request WHERE merged = 1''')]))
 
 
 def commit():

--- a/periodo/identifier.py
+++ b/periodo/identifier.py
@@ -46,6 +46,13 @@ def prefix(s):
         return PREFIX + s
 
 
+def unprefix(s):
+    if s.startswith(PREFIX):
+        return s[len(PREFIX):]
+    else:
+        return s
+
+
 def id_from_sequence(sequence):
     return prefix(add_check_digit(sequence))
 
@@ -88,16 +95,15 @@ def index_by_id(items):
     return {i['id']: i for i in items}
 
 
-def replace_skolem_ids(patch_or_obj, dataset):
+def replace_skolem_ids(patch_or_obj, dataset, removed_entity_keys):
 
     id_map = {}
 
+    existing_ids = set([unprefix(key) for key in removed_entity_keys])
     if (len(dataset) > 0):
-        existing_ids = set(chain.from_iterable(
+        existing_ids |= set(chain.from_iterable(
             ([cid] + list(c['definitions'].keys())
              for cid, c in dataset['periodCollections'].items())))
-    else:
-        existing_ids = set()
 
     def unused_identifier(id_generator, *args):
         for i in range(10):

--- a/periodo/provenance.py
+++ b/periodo/provenance.py
@@ -16,6 +16,7 @@ CONTEXT = {
     "generated": {"@id": "prov:generated", "@type": "@id"},
     "history": "@graph",
     "initialDataLoad": {"@id": "rdf:first", "@type": "@id"},
+    "invalidated": {"@id": "prov:invalidated", "@type": "@id"},
     "mergedAt": {"@id": "prov:endedAtTime", "@type": "xsd:dateTime"},
     "mergedPatches": {"@id": "rdf:rest"},
     "name": "foaf:name",
@@ -48,7 +49,8 @@ SELECT
   applied_to,
   resulted_in,
   created_entities,
-  updated_entities
+  updated_entities,
+  removed_entities
 FROM patch_request
 WHERE merged = 1
 ORDER BY id ASC
@@ -95,6 +97,9 @@ ORDER BY id ASC
                 entity_id + '?version={}'.format(row['applied_to'])]
             g.add(
                 (entity_version, PROV.wasRevisionOf, prev_entity_version))
+
+        for entity_id in json.loads(row['removed_entities']):
+            g.add((change, PROV.invalidated, PERIODO[entity_id]))
 
         for field, term in (('created_by', 'submitted'),
                             ('updated_by', 'updated'),

--- a/periodo/schema.sql
+++ b/periodo/schema.sql
@@ -28,6 +28,7 @@ CREATE TABLE patch_request (
   resulted_in INTEGER,
   created_entities TEXT NOT NULL DEFAULT '[]',
   updated_entities TEXT NOT NULL,
+  removed_entities TEXT NOT NULL,
   identifier_map TEXT,
 
   original_patch TEXT NOT NULL,

--- a/test/test-patch-remove-collection.json
+++ b/test/test-patch-remove-collection.json
@@ -1,0 +1,6 @@
+[
+  {
+    "op": "remove",
+    "path": "/periodCollections/p0trgkv"
+  }
+]

--- a/test/test-patch-remove-definition.json
+++ b/test/test-patch-remove-definition.json
@@ -1,0 +1,6 @@
+[
+  {
+    "op": "remove",
+    "path": "/periodCollections/p0trgkv/definitions/p0trgkvwbjd"
+  }
+]

--- a/test/test_identifiers.py
+++ b/test/test_identifiers.py
@@ -65,7 +65,7 @@ class TestIdentifiers(unittest.TestCase):
         with open(filepath('test-patch-adds-items.json')) as f:
             original_patch = JsonPatch(json.load(f))
         applied_patch, id_map = identifier.replace_skolem_ids(
-            original_patch, data)
+            original_patch, data, [])
         self.assertRegex(
             applied_patch.patch[0]['path'],
             r'^/periodCollections/p0trgkv/definitions/p0trgkv[%s]{4}$'
@@ -101,7 +101,7 @@ class TestIdentifiers(unittest.TestCase):
         with open(filepath('test-patch-replaces-definitions.json')) as f:
             original_patch = JsonPatch(json.load(f))
         applied_patch, id_map = identifier.replace_skolem_ids(
-            original_patch, data)
+            original_patch, data, [])
         self.assertEqual(
             applied_patch.patch[0]['path'],
             original_patch.patch[0]['path'])
@@ -120,7 +120,7 @@ class TestIdentifiers(unittest.TestCase):
         with open(filepath('test-patch-replaces-collections.json')) as f:
             original_patch = JsonPatch(json.load(f))
         applied_patch, id_map = identifier.replace_skolem_ids(
-            original_patch, data)
+            original_patch, data, [])
         self.assertEqual(
             applied_patch.patch[0]['path'],
             original_patch.patch[0]['path'])

--- a/test/test_patch.py
+++ b/test/test_patch.py
@@ -253,3 +253,145 @@ class TestPatchMethods(unittest.TestCase):
                     res.status_code, http.client.OK)
                 self.assertEqual(
                     res.headers['Content-Type'], 'application/json')
+
+    def test_remove_definition(self):
+        with open(filepath('test-patch-remove-definition.json')) as f:
+            patch1 = f.read()
+        with self.client as client:
+            res = client.patch(
+                '/d/',
+                data=patch1,
+                content_type='application/json',
+                headers={'Authorization': 'Bearer '
+                         + 'NTAwNWViMTgtYmU2Yi00YWMwLWIwODQtMDQ0MzI4OWIzMzc4'})
+            patch_url = urlparse(res.headers['Location']).path
+            res = client.post(
+                patch_url + 'merge',
+                headers={'Authorization': 'Bearer '
+                         + 'ZjdjNjQ1ODQtMDc1MC00Y2I2LThjODEtMjkzMmY1ZGFhYmI4'})
+            self.assertEqual(res.status_code, http.client.NO_CONTENT)
+            removed_entities = database.get_removed_entity_keys()
+            self.assertEqual(removed_entities, set(['p0trgkvwbjd']))
+            res = client.get('/trgkvwbjd',
+                             headers={'Accept': 'application/json'},
+                             follow_redirects=True)
+            self.assertEqual(res.status_code, http.client.GONE)
+            res = client.get('/trgkvwbjd.json',
+                             headers={'Accept': 'application/json'},
+                             follow_redirects=True)
+            self.assertEqual(res.status_code, http.client.GONE)
+            res = client.get('/trgkvwbjd?version=0',
+                             headers={'Accept': 'application/json'},
+                             follow_redirects=True)
+            self.assertEqual(res.status_code, http.client.NOT_FOUND)
+            res = client.get('/trgkvwbjd.json?version=0',
+                             headers={'Accept': 'application/json'},
+                             follow_redirects=True)
+            self.assertEqual(res.status_code, http.client.NOT_FOUND)
+            res = client.get('/trgkvwbjd?version=1',
+                             headers={'Accept': 'application/json'},
+                             follow_redirects=True)
+            self.assertEqual(res.status_code, http.client.OK)
+            res = client.get('/trgkvwbjd.json?version=1',
+                             headers={'Accept': 'application/json'},
+                             follow_redirects=True)
+            self.assertEqual(res.status_code, http.client.OK)
+
+            res = client.get('/h')
+
+            g = ConjunctiveGraph()
+            g.parse(format='json-ld', data=res.get_data(as_text=True))
+
+            invalidated = g.value(subject=PERIODO['p0h#change-2'],
+                                  predicate=PROV.invalidated,
+                                  any=False)
+            self.assertEqual(invalidated, PERIODO['p0trgkvwbjd'])
+
+            generated = list(g.objects(subject=PERIODO['p0h#change-2'],
+                                       predicate=PROV.generated))
+            self.assertEqual(len(generated), 2)
+            self.assertIn(PERIODO['p0d?version=2'], generated)
+            self.assertIn(PERIODO['p0trgkv?version=2'], generated)
+
+    def test_remove_collection(self):
+        with open(filepath('test-patch-remove-collection.json')) as f:
+            patch1 = f.read()
+        with self.client as client:
+            res = client.patch(
+                '/d/',
+                data=patch1,
+                content_type='application/json',
+                headers={'Authorization': 'Bearer '
+                         + 'NTAwNWViMTgtYmU2Yi00YWMwLWIwODQtMDQ0MzI4OWIzMzc4'})
+            patch_url = urlparse(res.headers['Location']).path
+            res = client.post(
+                patch_url + 'merge',
+                headers={'Authorization': 'Bearer '
+                         + 'ZjdjNjQ1ODQtMDc1MC00Y2I2LThjODEtMjkzMmY1ZGFhYmI4'})
+            self.assertEqual(res.status_code, http.client.NO_CONTENT)
+            removed_entities = database.get_removed_entity_keys()
+            self.assertEqual(removed_entities, set(['p0trgkv', 'p0trgkvwbjd']))
+            res = client.get('/trgkv',
+                             headers={'Accept': 'application/json'},
+                             follow_redirects=True)
+            self.assertEqual(res.status_code, http.client.GONE)
+            res = client.get('/trgkv.json',
+                             headers={'Accept': 'application/json'},
+                             follow_redirects=True)
+            self.assertEqual(res.status_code, http.client.GONE)
+            res = client.get('/trgkv?version=0',
+                             headers={'Accept': 'application/json'},
+                             follow_redirects=True)
+            self.assertEqual(res.status_code, http.client.NOT_FOUND)
+            res = client.get('/trgkv.json?version=0',
+                             headers={'Accept': 'application/json'},
+                             follow_redirects=True)
+            self.assertEqual(res.status_code, http.client.NOT_FOUND)
+            res = client.get('/trgkv?version=1',
+                             headers={'Accept': 'application/json'},
+                             follow_redirects=True)
+            self.assertEqual(res.status_code, http.client.OK)
+            res = client.get('/trgkv.json?version=1',
+                             headers={'Accept': 'application/json'},
+                             follow_redirects=True)
+            self.assertEqual(res.status_code, http.client.OK)
+            res = client.get('/trgkvwbjd',
+                             headers={'Accept': 'application/json'},
+                             follow_redirects=True)
+            self.assertEqual(res.status_code, http.client.GONE)
+            res = client.get('/trgkvwbjd.json',
+                             headers={'Accept': 'application/json'},
+                             follow_redirects=True)
+            self.assertEqual(res.status_code, http.client.GONE)
+            res = client.get('/trgkvwbjd?version=0',
+                             headers={'Accept': 'application/json'},
+                             follow_redirects=True)
+            self.assertEqual(res.status_code, http.client.NOT_FOUND)
+            res = client.get('/trgkvwbjd.json?version=0',
+                             headers={'Accept': 'application/json'},
+                             follow_redirects=True)
+            self.assertEqual(res.status_code, http.client.NOT_FOUND)
+            res = client.get('/trgkvwbjd?version=1',
+                             headers={'Accept': 'application/json'},
+                             follow_redirects=True)
+            self.assertEqual(res.status_code, http.client.OK)
+            res = client.get('/trgkvwbjd.json?version=1',
+                             headers={'Accept': 'application/json'},
+                             follow_redirects=True)
+            self.assertEqual(res.status_code, http.client.OK)
+
+            res = client.get('/h')
+
+            g = ConjunctiveGraph()
+            g.parse(format='json-ld', data=res.get_data(as_text=True))
+
+            invalidated = list(g.objects(subject=PERIODO['p0h#change-2'],
+                                         predicate=PROV.invalidated))
+            self.assertEqual(len(invalidated), 2)
+            self.assertIn(PERIODO['p0trgkv'], invalidated)
+            self.assertIn(PERIODO['p0trgkvwbjd'], invalidated)
+
+            generated = g.value(subject=PERIODO['p0h#change-2'],
+                                predicate=PROV.generated,
+                                any=False)
+            self.assertEqual(generated, PERIODO['p0d?version=2'])


### PR DESCRIPTION
Removed entities now show up as `prov:invalidated` in the history, and return `410 Gone` when requested. Addresses #14 