### PR TITLE
Add stream-consuming middleware.

### DIFF
--- a/periodo/__init__.py
+++ b/periodo/__init__.py
@@ -5,10 +5,12 @@ from flask_restful import Api
 from periodo.secrets import (
     SECRET_KEY, DB, ORCID_CLIENT_ID, ORCID_CLIENT_SECRET)
 from periodo.utils import UUIDConverter
+from periodo.middleware import StreamConsumingMiddleware
 
 app = Flask(__name__)
 app.secret_key = SECRET_KEY
 app.url_map.converters['uuid'] = UUIDConverter
+app.wsgi_app = StreamConsumingMiddleware(app.wsgi_app)
 principal = Principal(app, use_sessions=False)
 
 app.config.update(

--- a/periodo/middleware.py
+++ b/periodo/middleware.py
@@ -1,0 +1,20 @@
+from werkzeug.wsgi import LimitedStream
+
+
+class StreamConsumingMiddleware(object):
+
+    def __init__(self, app):
+        self.app = app
+
+    def __call__(self, env, start_response):
+        stream = LimitedStream(env['wsgi.input'],
+                               int(env['CONTENT_LENGTH'] or 0))
+        env['wsgi.input'] = stream
+        app_iter = self.app(env, start_response)
+        try:
+            stream.exhaust()
+            for event in app_iter:
+                yield event
+        finally:
+            if hasattr(app_iter, 'close'):
+                app_iter.close()

--- a/test/test_authorization.py
+++ b/test/test_authorization.py
@@ -132,6 +132,7 @@ class TestAuthorization(unittest.TestCase):
 
             res = client.post(
                 patch_url + 'merge',
+                buffered=True,
                 headers={'Authorization': 'Bearer '
                          + 'ZjdjNjQ1ODQtMDc1MC00Y2I2LThjODEtMjkzMmY1ZGFhYmI4'})
             self.assertEqual(res.status_code, http.client.NO_CONTENT)
@@ -188,6 +189,7 @@ class TestAuthorization(unittest.TestCase):
             patch_path = urlparse(res.headers['Location']).path
             res = client.post(
                 patch_path + 'merge',
+                buffered=True,
                 headers={'Authorization': 'Bearer '
                          + 'ZjdjNjQ1ODQtMDc1MC00Y2I2LThjODEtMjkzMmY1ZGFhYmI4'})
             res = client.put(

--- a/test/test_bags.py
+++ b/test/test_bags.py
@@ -81,7 +81,9 @@ class TestBags(unittest.TestCase):
                          + 'NTAwNWViMTgtYmU2Yi00YWMwLWIwODQtMDQ0MzI4OWIzMzc4'})
             self.assertEqual(res.status_code, http.client.CREATED)
             res = client.get(
-                res.headers['Location'], headers={
+                res.headers['Location'],
+                buffered=True,
+                headers={
                     'If-None-Match':
                     'W/"bag-6f2c64e2-c65f-4e2d-b028-f89dfb71ce69-version-0"'})
             self.assertEqual(res.status_code, http.client.NOT_MODIFIED)

--- a/test/test_patch.py
+++ b/test/test_patch.py
@@ -86,6 +86,7 @@ class TestPatchMethods(unittest.TestCase):
             '/d/',
             data=self.patch,
             content_type='application/json',
+            buffered=True,
             headers={'Authorization': 'Bearer '
                          + 'NTAwNWViMTgtYmU2Yi00YWMwLWIwODQtMDQ0MzI4OWIzMzc4'})
         patch_url = urlparse(res.headers['Location']).path
@@ -129,6 +130,7 @@ class TestPatchMethods(unittest.TestCase):
             patch_url = urlparse(res.headers['Location']).path
             res = client.post(
                 patch_url + 'merge',
+                buffered=True,
                 headers={'Authorization': 'Bearer '
                          + 'ZjdjNjQ1ODQtMDc1MC00Y2I2LThjODEtMjkzMmY1ZGFhYmI4'})
             self.assertEqual(res.status_code, http.client.NO_CONTENT)
@@ -162,6 +164,7 @@ class TestPatchMethods(unittest.TestCase):
             patch_url = urlparse(res.headers['Location']).path
             res = client.post(
                 patch_url + 'reject',
+                buffered=True,
                 headers={'Authorization': 'Bearer '
                          + 'ZjdjNjQ1ODQtMDc1MC00Y2I2LThjODEtMjkzMmY1ZGFhYmI4'})
             self.assertEqual(res.status_code, http.client.NO_CONTENT)
@@ -222,6 +225,7 @@ class TestPatchMethods(unittest.TestCase):
             patch_url = urlparse(res.headers['Location']).path
             res = client.post(
                 patch_url + 'merge',
+                buffered=True,
                 headers={'Authorization': 'Bearer '
                          + 'ZjdjNjQ1ODQtMDc1MC00Y2I2LThjODEtMjkzMmY1ZGFhYmI4'})
             self.assertEqual(res.status_code, http.client.NO_CONTENT)
@@ -234,6 +238,7 @@ class TestPatchMethods(unittest.TestCase):
             patch_url = urlparse(res.headers['Location']).path
             res = client.post(
                 patch_url + 'merge',
+                buffered=True,
                 headers={'Authorization': 'Bearer '
                          + 'ZjdjNjQ1ODQtMDc1MC00Y2I2LThjODEtMjkzMmY1ZGFhYmI4'})
             self.assertEqual(res.status_code, http.client.NO_CONTENT)
@@ -328,6 +333,7 @@ class TestPatchMethods(unittest.TestCase):
             patch_url = urlparse(res.headers['Location']).path
             res = client.post(
                 patch_url + 'merge',
+                buffered=True,
                 headers={'Authorization': 'Bearer '
                          + 'ZjdjNjQ1ODQtMDc1MC00Y2I2LThjODEtMjkzMmY1ZGFhYmI4'})
             self.assertEqual(res.status_code, http.client.NO_CONTENT)
@@ -387,6 +393,7 @@ class TestPatchMethods(unittest.TestCase):
             patch_url = urlparse(res.headers['Location']).path
             res = client.post(
                 patch_url + 'merge',
+                buffered=True,
                 headers={'Authorization': 'Bearer '
                          + 'ZjdjNjQ1ODQtMDc1MC00Y2I2LThjODEtMjkzMmY1ZGFhYmI4'})
             self.assertEqual(res.status_code, http.client.NO_CONTENT)

--- a/test/test_provenance.py
+++ b/test/test_provenance.py
@@ -59,6 +59,7 @@ class TestProvenance(unittest.TestCase):
             patch_url = urlparse(res1.headers['Location']).path
             client.post(
                 patch_url + 'merge',
+                buffered=True,
                 headers={'Authorization': 'Bearer '
                          + 'ZjdjNjQ1ODQtMDc1MC00Y2I2LThjODEtMjkzMmY1ZGFhYmI4'})
             res2 = client.get('/h')

--- a/test/test_representation.py
+++ b/test/test_representation.py
@@ -150,6 +150,7 @@ WHERE {
                          + 'NTAwNWViMTgtYmU2Yi00YWMwLWIwODQtMDQ0MzI4OWIzMzc4'})
             res = client.post(
                 urlparse(res.headers['Location']).path + 'merge',
+                buffered=True,
                 headers={'Authorization': 'Bearer '
                          + 'ZjdjNjQ1ODQtMDc1MC00Y2I2LThjODEtMjkzMmY1ZGFhYmI4'})
         data = self.client.get(
@@ -202,7 +203,7 @@ WHERE {
         res1 = self.client.get('/d/')
         self.assertEqual(res1.status_code, http.client.OK)
         self.assertEqual(res1.get_etag(), ('periodo-dataset-version-1', True))
-        res2 = self.client.get('/d/', headers={
+        res2 = self.client.get('/d/', buffered=True, headers={
             'If-None-Match': 'W/"periodo-dataset-version-1"'})
         self.assertEqual(res2.status_code, http.client.NOT_MODIFIED)
 


### PR DESCRIPTION
According to the uWSGI docs:

> If an HTTP request has a body (like a POST request generated by a
  form), you have to read (consume) it in your application. If you do
  not do this, the communication socket with your webserver may be
  clobbered. [1]

StreamConsumingMiddleware ensures that the body is consumed. Without
it, in cases where a large request body is streamed but (for example)
authentication fails, communication between nginx and uWSGI fails,
resulting in a 502 Bad Gateway.

Unfortunately, consuming the incoming stream properly in this way
confuses the Werkzeug test client in cases where no content is
returned (as is often the case with updates). So in these cases we
have to pass `buffered=True` to make the test client work properly.

[1] http://uwsgi-docs.readthedocs.io/en/latest/ThingsToKnow.html