### PR TITLE
Install `wheel` python package before requirements.txt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,8 @@ endif
 
 .PHONY: setup
 setup: $(PYTHON3) requirements.txt
-	$(PIP3) install -q -r requirements.txt
+	$(PIP3) install wheel
+	$(PIP3) install -r requirements.txt
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
I was getting errors running `make setup` without doing this