### PR TITLE
Fix rdflib deprecation warnings in tests

### DIFF
--- a/test/pytest.ini
+++ b/test/pytest.ini
@@ -1,3 +1,5 @@
 [pytest]
 markers =
     client_auth_token(token): token for HTTP Bearer authentication
+filterwarnings =
+    ignore:ConjunctiveGraph is deprecated:DeprecationWarning:rdflib

--- a/test/test_patch.py
+++ b/test/test_patch.py
@@ -2,7 +2,7 @@ import httpx
 import json
 import pytest
 import re
-from rdflib import Dataset
+from rdflib import Graph
 from rdflib.namespace import Namespace
 from urllib.parse import urlparse
 from periodo import app, database, identifier, cache, DEV_SERVER_NAME
@@ -267,7 +267,7 @@ def test_remove_period(client, submit_and_merge_patch):
     assert res.status_code == httpx.codes.OK
 
     res = client.get("/history.nt")
-    g = Dataset()
+    g = Graph()
     g.parse(format="nt", data=res.text)
 
     generated = list(g.objects(subject=HOST["h#change-2"], predicate=PROV.generated))
@@ -319,7 +319,7 @@ def test_remove_authority(client, submit_and_merge_patch):
     assert res.status_code == httpx.codes.OK
 
     res = client.get("/h.nt")
-    g = Dataset()
+    g = Graph()
     g.parse(format="nt", data=res.text)
 
     generated = g.value(subject=HOST["h#change-2"], predicate=PROV.generated, any=False)

--- a/test/test_provenance.py
+++ b/test/test_provenance.py
@@ -1,7 +1,7 @@
 import httpx
 import pytest
 import re
-from rdflib import Dataset, Literal, URIRef
+from rdflib import Graph, Literal, URIRef
 from rdflib.namespace import Namespace, RDFS, FOAF, RDF
 from urllib.parse import urlparse
 from periodo import DEV_SERVER_NAME
@@ -51,7 +51,7 @@ def test_get_history(
     assert res.status_code == httpx.codes.OK
     assert res.headers["Content-Type"] == "application/n-triples"
 
-    g = Dataset()
+    g = Graph()
     g.parse(format="nt", data=res.text)
 
     # Initial data load


### PR DESCRIPTION
## Summary

- Replace `Dataset` with `Graph` in `test_patch.py` and `test_provenance.py` for N-Triples parsing — N-Triples is a triple-only format so there's no need for a context-aware graph, and using `Graph` avoids the `Dataset.default_context is deprecated` path in rdflib's `ConjunctiveGraph` parent methods (65 warnings eliminated)
- Add a targeted `filterwarnings` rule to `pytest.ini` suppressing `ConjunctiveGraph is deprecated` from rdflib — this warning fires from inside rdflib's own JSON-LD parser and cannot be avoided from our call sites (3 warnings suppressed)

## Test plan

- [ ] `make test` passes with 88 tests and 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)